### PR TITLE
remove NETStandard.Library import checks

### DIFF
--- a/SAM_Tas/SAM.Analytical.Tas.TPD/SAM.Analytical.Tas.TPD.csproj
+++ b/SAM_Tas/SAM.Analytical.Tas.TPD/SAM.Analytical.Tas.TPD.csproj
@@ -153,11 +153,4 @@
     <Folder Include="Interfaces\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets'))" />
-  </Target>
 </Project>


### PR DESCRIPTION

### Issues addressed by this PR


Fixes #

- Build failure due to missing `packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets` file. The check for this in the PrepareForBuild stage doesn't seem to be necessary.
